### PR TITLE
Bug/env home unset

### DIFF
--- a/lib/jerakia/client.rb
+++ b/lib/jerakia/client.rb
@@ -25,7 +25,7 @@ class Jerakia
 
     def self.config_file
       [
-        File.join(ENV['HOME'], '.jerakia', 'jerakia.yaml'),
+        File.join(ENV['HOME'] || '', '.jerakia', 'jerakia.yaml'),
         '/etc/jerakia/jerakia.yaml'
       ]. each do |filename|
         return filename if File.exists?(filename)

--- a/lib/jerakia/client/token.rb
+++ b/lib/jerakia/client/token.rb
@@ -5,7 +5,7 @@ class Jerakia
       class << self
         def load_from_file
           [
-            File.join(ENV['HOME'], ".jerakia", "jerakia.yaml"),
+            File.join(ENV['HOME'] || '', ".jerakia", "jerakia.yaml"),
             "/etc/jerakia/jerakia.yaml",
           ]. each do |file|
             if File.exists?(file)


### PR DESCRIPTION
This prevents errors in earlier versions of Puppetserver that unset the HOME environment variable

